### PR TITLE
Adding StreamOutput so compiled eo examples can be output to the console

### DIFF
--- a/eo-compiler/pom.xml
+++ b/eo-compiler/pom.xml
@@ -50,5 +50,9 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/eo-compiler/src/main/java/org/eolang/compiler/Main.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/Main.java
@@ -23,7 +23,10 @@
  */
 package org.eolang.compiler;
 
+import java.io.IOException;
 import java.io.PrintStream;
+import java.nio.charset.Charset;
+import org.apache.commons.io.IOUtils;
 
 /**
  * Main.
@@ -66,12 +69,41 @@ public final class Main {
     /**
      * Entry point.
      */
+    @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
     public void exec() {
-        if ("--help".equals(this.args[0])) {
-            this.stdout.append("It is just a skeleton");
-        } else {
+        if (this.args.length == 0) {
             this.stdout.append("Usage: --help");
+        } else if ("--help".equals(this.args[0])) {
+            this.stdout.append("This is just a skeleton, but ");
+            this.stdout.append("please use --demo for compilation examples.");
+        } else if ("--demo".equals(this.args[0])) {
+            try {
+                final String[] files = {
+                    "book.eo", "car.eo", "fibonacci.eo",
+                    "multitypes.eo", "pixel.eo", "zero.eo",
+                };
+                for (final String file : files) {
+                    this.stdout.append("\n=====================\n");
+                    this.stdout.append("EOLANG:\n");
+                    this.stdout.append(
+                        IOUtils.toString(
+                            this.getClass().getResourceAsStream(file),
+                            Charset.defaultCharset()
+                        )
+                    );
+                    this.stdout.append("\nJAVA:\n");
+                    final Program program = new Program(
+                        IOUtils.toString(
+                            this.getClass().getResourceAsStream(file),
+                            Charset.defaultCharset()
+                        )
+                    );
+                    program.save(new StreamOutput(this.stdout));
+                    this.stdout.append("\n=====================\n\n");
+                }
+            } catch (final IOException ex) {
+                this.stdout.append("Error reading resource file.");
+            }
         }
     }
-
 }

--- a/eo-compiler/src/main/java/org/eolang/compiler/StreamOutput.java
+++ b/eo-compiler/src/main/java/org/eolang/compiler/StreamOutput.java
@@ -1,0 +1,56 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 eolang.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package org.eolang.compiler;
+
+import java.io.PrintStream;
+import java.nio.file.Path;
+
+/**
+ * StreamOutput is used for outputing to a PrintStream rather than to a file.
+ *
+ * @author John Page (johnpagedev@gmail.com)
+ * @version $Id$
+ * @since 0.1
+ */
+public final class StreamOutput implements Output {
+
+    /**
+     * The PrintStream to output the file contents to.
+     */
+    private final PrintStream stream;
+
+    /**
+     * Ctor.
+     *
+     * @param stream The PrintStream to output the file contents to.
+     */
+    public StreamOutput(final PrintStream stream) {
+        this.stream = stream;
+    }
+
+    @Override
+    public void save(final Path file, final String content) {
+        this.stream.append(content);
+    }
+}

--- a/eo-compiler/src/main/resources/org/eolang/compiler/book.eo
+++ b/eo-compiler/src/main/resources/org/eolang/compiler/book.eo
@@ -1,0 +1,2 @@
+type Book:
+    Text text()

--- a/eo-compiler/src/main/resources/org/eolang/compiler/car.eo
+++ b/eo-compiler/src/main/resources/org/eolang/compiler/car.eo
@@ -1,0 +1,4 @@
+type Car:
+    Money cost()
+    Bytes picture()
+    Car moveTo(Coordinates coords)

--- a/eo-compiler/src/main/resources/org/eolang/compiler/fibonacci.eo
+++ b/eo-compiler/src/main/resources/org/eolang/compiler/fibonacci.eo
@@ -1,0 +1,17 @@
+object fibonacci as Int:
+  Int @n
+  ctor():
+    fibonacci:
+      1
+  Int int():
+    if:
+      firstIsLess:
+        @n
+        2
+      1
+      plus:
+        @n
+        fibonacci:
+          minus:
+            @n
+            1

--- a/eo-compiler/src/main/resources/org/eolang/compiler/multitypes.eo
+++ b/eo-compiler/src/main/resources/org/eolang/compiler/multitypes.eo
@@ -1,0 +1,7 @@
+type Number:
+    Integral integral()
+    Decimal decimal()
+
+type Text:
+    Number length()
+    Collection lines()

--- a/eo-compiler/src/main/resources/org/eolang/compiler/pixel.eo
+++ b/eo-compiler/src/main/resources/org/eolang/compiler/pixel.eo
@@ -1,0 +1,2 @@
+type Pixel:
+  Pixel moveTo(Integer x, Integer y)

--- a/eo-compiler/src/main/resources/org/eolang/compiler/zero.eo
+++ b/eo-compiler/src/main/resources/org/eolang/compiler/zero.eo
@@ -1,0 +1,4 @@
+object zero as Money, Int:
+    Int @amount
+    Text @currency
+    ctor(Int amount, Text currency)


### PR DESCRIPTION
This was useful for me as I was working out what the compiler does exactly. It also shows some deficiencies in the current compiler.

The command line argument "--demo" can now be used to show the various eo example files and their compiled output.

I had to duplicate the resource eo files, which is a shame, but I don't yet know how to avoid that.